### PR TITLE
Shell og Dockerfile nå også som mulige languages, ikke bare possible_container_scan...

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/Main.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/Main.kt
@@ -23,7 +23,7 @@ import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.system.measureTimeMillis
 
-val LANGUAGES = setOf("JavaScript", "Java", "TypeScript", "C#", "Kotlin", "Go")
+val LANGUAGES = setOf("JavaScript", "Java", "TypeScript", "C#", "Kotlin", "Go", "Shell", "Dockerfile")
 val POSSIBLE_CONTAINER_SCAN = setOf("JavaScript", "Java", "TypeScript", "Kotlin", "Shell", "Dockerfile")
 const val GITHUB_OWNER = "digipost";
 const val TIMOUT_PUBLISH_VULNS = 1000L * 60 * 2


### PR DESCRIPTION
Min forrige endring hadde ingenting effekt, ettersom disse to språkene uansett ble ignorert av appen.