### PR TITLE
Hent severity limit fra properties i stedet for env

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/Main.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/Main.kt
@@ -50,13 +50,6 @@ suspend fun main(): Unit = coroutineScope {
     val severityLimitForNotifications = SecurityAdvisorySeverity.safeValueOf(getEnvOrProp("severity_limit").orElse("UNKNOWN"))
     val logger = LoggerFactory.getLogger("no.digipost.github.monitoring.Main")
     val prometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    if (getEnvOrProp("severity_limit").isPresent) {
-        logger.warn("Severity limit " + getEnvOrProp("severity_limit").get())
-    }
-    else {
-        logger.warn("Severity limit ikke satt")
-        System.getProperties()
-    }
 
     ApplicationInfoMetrics().bindTo(prometheusMeterRegistry)
 

--- a/src/main/kotlin/no/digipost/github/monitoring/Main.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/Main.kt
@@ -54,16 +54,16 @@ suspend fun main(): Unit = coroutineScope {
         }
     }
 
-    if (System.getenv().containsKey("severity_limit")) {
-        println("Severity limit " + System.getenv("severity_limit"))
-    }
-    else {
-        println("Severity limit ikke satt")
-        println(System.getenv())
-    }
     val severityLimitForNotifications = if (System.getenv().containsKey("severity_limit")) SecurityAdvisorySeverity.safeValueOf(System.getenv("severity_limit")) else UNKNOWN__
     val logger = LoggerFactory.getLogger("no.digipost.github.monitoring.Main")
     val prometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    if (System.getenv().containsKey("severity_limit")) {
+        logger.warn("Severity limit " + System.getenv("severity_limit"))
+    }
+    else {
+        logger.warn("Severity limit ikke satt")
+        logger.warn(System.getenv().toString())
+    }
 
     ApplicationInfoMetrics().bindTo(prometheusMeterRegistry)
 


### PR DESCRIPTION
Per nå har det ikke fungert å kun advare om kritiske sårbarheter, fordi vi har prøvd å hente severity_limit fra env. Den ligger i properties, så jeg har stjålet getEnvOrProp() fra auditlog-innsyn. 