### PR TITLE
Bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           DPOST_HOME: /tmp
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Upload for feilet bygg


### PR DESCRIPTION
Github Actions won't run on the deprecated version v3