### PR TITLE
Catch JsonSyntaxException when querying github api for workflow runs

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/Domain.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/Domain.kt
@@ -1,7 +1,6 @@
 package no.digipost.github.monitoring
 import com.github.graphql.client.type.SecurityAdvisorySeverity
 import com.google.gson.annotations.SerializedName
-import java.time.ZonedDateTime
 
 data class Repository(
     val owner: String,

--- a/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
@@ -1,6 +1,7 @@
 package no.digipost.github.monitoring
 
 import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -30,7 +31,11 @@ class GithubApiClient(private val githubToken: String) {
     private fun hasContainerScanWorkflow(repo: Repository): Boolean {
         return try {
             fetchWorkflows(repo).workflows.any { it.path.contains(SCAN_CONTAINERS_YML) }
-        } catch (e: NullPointerException) {
+        } catch (e: NullPointerException ) {
+            logger.warn("NullPointerException when checking for container scan workflow in repository: ${repo.name}", e)
+            false
+        } catch (e: JsonSyntaxException) {
+            logger.warn("JsonSyntaxException when checking for container scan workflow in repository: ${repo.name}", e)
             false
         }
     }

--- a/src/main/kotlin/no/digipost/github/monitoring/GithubGraphql.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/GithubGraphql.kt
@@ -9,7 +9,6 @@ import java.io.IOException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.internal.immutableListOf


### PR DESCRIPTION
We're experiencing the following exception from time to time:

Exception in thread "main" com.google.gson.JsonSyntaxException:
  java.lang.IllegalStateException: Expected BEGIN_OBJECT but was
                                   STRING at line 1 column 1 path

I can think of a couple different cases where the github API may reply with a string rather than json, so it's not unreasonable to handle this. However, we're not particularly interested in doing anything other than keeping the prosess alive and hoping the following interation is successful. In order to keep track of how often this occurs, I added some logging.