### PR TITLE
Legg til feilhåndtering på kall til HTTP-client ifmb slack-integrasjon

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/SlackClient.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/SlackClient.kt
@@ -14,10 +14,14 @@ class SlackClient(private val webhookUrl: String) {
 
     fun sendToSlack(vulnerability: Vulnerability) {
         val request = slackRequest("Ny sårbarhet: ${toSlackInformation(vulnerability)}")
-        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        try {
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-        if (response.statusCode() != 200) {
-            logger.warn("Failed to report new vulnerability to slack. Status code ${response.statusCode()}, body: ${response.body()}")
+            if (response.statusCode() != 200) {
+                logger.warn("Failed to report new vulnerability to slack. Status code ${response.statusCode()}, body: ${response.body()}")
+            }
+        } catch (e: Exception) {
+            logger.error("Error when sending vulnerability to Slack", e)
         }
     }
 


### PR DESCRIPTION
Kallet mot slack ved nye sårbarheter tryner og dreper hele appen, så første løsning er å catche feilen og logge en error, slik at hele appen ikke tryner. Neste steg blir å finne ut hvorfor det feiler, og rette opp dette.