### PR TITLE
Unngå parsing med Gson dersom response-body fra github-api'et er null

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
@@ -51,6 +51,12 @@ class GithubApiClient(private val githubToken: String) {
         val uri: String = GITHUB_WORKFLOW_RUNS_URI.format(repo.owner, repo.name, datetimeRange(days), days)
         val request: HttpRequest = githubApiRequest(uri)
         val response: HttpResponse<String> = client.send(request, BodyHandlers.ofString())
+
+        if (response.body() == null) {
+            logger.warn("Null body received when fetching workflow runs for ${repo.name}")
+            return emptyList()
+        }
+
         val workflowRuns: WorkflowRuns = Gson().fromJson(response.body(), WorkflowRuns::class.java)
         return workflowRuns.workflowRuns?.filter { it.isScheduledContainerScan() } ?: run {
             logger.warn("workflowRuns is Null. repositoryname={}", repo.name)


### PR DESCRIPTION
Dersom github av en eller annen grunn returnerer null som body vil fromJson-funksjonen også returnere null pga. implementasjonen i Gson. Dette medfører NullPointerException i koden pga. val'en workflowRuns ikke er nullable.

Vi håndterer dette på samme måte som vi har gjort med øvrige try-catch-blokker - returnere tom liste og håpe det går bra neste kjøring.