### PR TITLE
Spesifiser slack-kanal for testing av ny slack-app

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/SlackClient.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/SlackClient.kt
@@ -35,7 +35,7 @@ class SlackClient(private val webhookUrl: String) {
         return HttpRequest
             .newBuilder()
             .uri(URI.create(webhookUrl))
-            .POST(HttpRequest.BodyPublishers.ofString("{ \"text\": \"$message\"}"))
+            .POST(HttpRequest.BodyPublishers.ofString("{ \"text\": \"$message\", \"channel\": \"#vulnerability-reporter-testing\" }"))
             .header("Content-Type", "application/json")
             .build()
     }


### PR DESCRIPTION
Vi skal legge til en ny slack-app med ny webhook-url, men spesifiserer her at vi skal poste til en test-kanal for å sjekke at det funker før vi fjerner dette igjen.