### PR TITLE
Catch error when parsing JSON from github

### DIFF
--- a/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
+++ b/src/main/kotlin/no/digipost/github/monitoring/GithubApiClient.kt
@@ -57,10 +57,15 @@ class GithubApiClient(private val githubToken: String) {
             return emptyList()
         }
 
-        val workflowRuns: WorkflowRuns = Gson().fromJson(response.body(), WorkflowRuns::class.java)
-        return workflowRuns.workflowRuns?.filter { it.isScheduledContainerScan() } ?: run {
-            logger.warn("workflowRuns is Null. repositoryname={}", repo.name)
-            emptyList()
+        try {
+            val workflowRuns: WorkflowRuns = Gson().fromJson(response.body(), WorkflowRuns::class.java)
+            return workflowRuns.workflowRuns?.filter { it.isScheduledContainerScan() } ?: run {
+                logger.warn("workflowRuns is Null. repositoryname={}", repo.name)
+                emptyList()
+            }
+        } catch (e: JsonSyntaxException) {
+            logger.warn("Exception when parsing response body for workflow runs. Repositoryname ${repo.name}", e)
+            return emptyList()
         }
     }
 


### PR DESCRIPTION
We're getting issues with JsonSyntaxException of type Expected BEGIN_OBJECT but was STRING.

Continuing the tradition of catching these exceptions, returning an empty list, and hoping a following run will be successful and thus report correct container scan metrics.